### PR TITLE
add links to galaxy repositories and fix install code

### DIFF
--- a/index.html
+++ b/index.html
@@ -33,10 +33,10 @@ Whenever possible, the modules for this effort will take advantage of the native
 
 <p><span style="font-size: larger;"><strong>Currently supported subsystems</strong></span><br>
 <ul>
-<li>email (postfix)</li>
+<li><a href="https://galaxy.ansible.com/linux-system-roles/postfix/">email (postfix)</li>
 <li><a href="https://galaxy.ansible.com/linux-system-roles/kdump/">kdump (kernel crash dump)</a></li>
-<li>networking</li>
-<li>selinux</li>
+<li><a href="https://galaxy.ansible.com/linux-system-roles/network/">network</a></li>
+<li><a href="https://galaxy.ansible.com/linux-system-roles/selinux/">selinux</a></li>
 <li><a href="https://galaxy.ansible.com/linux-system-roles/timesync/">timesync</a></li>
 </ul></p>
 
@@ -52,11 +52,11 @@ First, install Ansible on the system that you intend to use as your "control nod
 
 <p>Next, pull these roles from Ansible Galaxy.
 <br><code><br>
-# ansible-galaxy install linux-system-api.email<br>
-# ansible-galaxy install linux-system-api.kdump<br>
-# ansible-galaxy install linux-system-api.networking<br>
-# ansible-galaxy install linux-system-api.selinux<br>
-# ansible-galaxy install linux-system-api.timesync<br>
+# ansible-galaxy install linux-system-roles.email<br>
+# ansible-galaxy install linux-system-roles.kdump<br>
+# ansible-galaxy install linux-system-roles.network<br>
+# ansible-galaxy install linux-system-roles.selinux<br>
+# ansible-galaxy install linux-system-roles.timesync<br>
 </code>
 </p>
 <p><span style="font-size: larger;"><strong>Contributing</strong></span><br>


### PR DESCRIPTION
the "install" examples used the wrong name for the components,
"linux-system-api" instead of "linux-system-roles".

Also, add links to the galaxy repositories.