### PR TITLE
Change IRC references from freenode to Libera.chat.

### DIFF
--- a/community.md
+++ b/community.md
@@ -11,4 +11,4 @@ Do you need help solving a linux-system-roles related problem? Do you want to di
 
 ## IRC
 
-#systemroles@freenode.org ([Web IRC](https://webchat.freenode.net/?channels=#systemroles))
+#[systemroles@libera.chat](irc://irc.libera.chat/systemroles)

--- a/contribute.md
+++ b/contribute.md
@@ -166,7 +166,7 @@ conflicts. On the rebase you have to compare what the other person added to what
 added, and merge both file versions into one that combines it all.
 
 - If you have any doubt, do not hesitate to ask! You can join IRC channel \#systemroles
-  on freenode, or ask on the PR/issue itself.
+  on Libera.chat, or ask on the PR/issue itself.
 
 ### Best Practices
 
@@ -315,8 +315,8 @@ The mailing list for developers: systemroles@lists.fedorahosted.org
 
 [Archive of the mailing list](https://lists.fedorahosted.org/archives/list/systemroles@lists.fedorahosted.org/)
 
-If you are using IRC, join the `#systemroles` IRC channel on 
-[freenode](https://freenode.net/kb/answer/chat)
+If you are using IRC, join the `[#systemroles](irc://irc.libera.chat/systemroles)` IRC channel on 
+[Libera.chat](https://libera.chat)
 
 
 *Thanks for contributing and happy coding!!*


### PR DESCRIPTION
This patch updates information on accessing system roles IRC channels,
which have been migrated to Libera.chat.