### PR TITLE
Update Repo Landing page

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 linux-system-roles.github.io web page
 ***
 
-For more information about The collection please refer to our website [linux-system-roles.github.io](https://linux-system-roles.github.io/)
+For more information about the roles/collection please refer to our website [linux-system-roles.github.io](https://linux-system-roles.github.io/)
 
-A more direct readme concerning the collection can be found [here](index.md)
+A more direct readme concerning the roles/collection can be found [here](index.md)
 
 This page bases on the [slim-pickins-jekyll-theme](http://chrisanthropic.github.io/slim-pickins-jekyll-theme/) with several changes on top.
 


### PR DESCRIPTION
I had went straight to the repo from the automation hub, and found the default Readme to be underwhelming. I had thought to change it to just the index.md, but saw how impracticable that change would be. 

I am hoping that this should help anyone else who arrives here like I did, and points them in the right direction.

Thanks,