### PR TITLE
add support for containers; add c9s; add podman to roadmap; add email, irc, gh discussion links

### DIFF
--- a/_includes/asides/quick_links.html
+++ b/_includes/asides/quick_links.html
@@ -2,6 +2,15 @@
   <h2>Quick Links</h2>
   <ul>
     <li>
+      <a href="mailto:systemroles@lists.fedorahosted.org">Email</a>
+    </li>
+    <li>
+      <a href="https://app.element.io/#/room/#systemroles:libera.chat">IRC #systemroles</a>
+    </li>
+    <li>
+      <a href="https://github.com/orgs/linux-system-roles/discussions">GitHub Discussions</a>
+    </li>
+    <li>
       <a href="https://github.com/linux-system-roles">GitHub</a>
     </li>
     <li>

--- a/download/linux-system-roles.json
+++ b/download/linux-system-roles.json
@@ -26,6 +26,7 @@
     {
       "name": "fedora-34",
       "compose": "https://kojipkgs.fedoraproject.org/compose/cloud/latest-Fedora-Cloud-34/compose/",
+      "container": "registry.fedoraproject.org/fedora-toolbox:34",
       "openstack_image": "Fedora-Cloud-Base-34",
       "upload_results": true,
       "min_ansible_version": "2.9"
@@ -33,6 +34,7 @@
     {
       "name": "fedora-35",
       "compose": "https://kojipkgs.fedoraproject.org/compose/cloud/latest-Fedora-Cloud-35/compose/",
+      "container": "registry.fedoraproject.org/fedora-toolbox:35",
       "openstack_image": "Fedora-Cloud-Base-35",
       "upload_results": true,
       "min_ansible_version": "2.9"
@@ -49,7 +51,6 @@
         {
           "name": "Change repos to use vault",
           "hosts": "all",
-          "become": true,
           "gather_facts": false,
           "tasks": [
             { "name": "fix yum repos to use vault.centos.org",
@@ -63,6 +64,7 @@
     {
       "name": "centos-7",
       "source": "https://cloud.centos.org/centos/7/images/CentOS-7-x86_64-GenericCloud-2111.qcow2c",
+      "container": "quay.io/centos/centos:centos7",
       "openstack_image": "CentOS-7-x86_64-GenericCloud-released-latest",
       "env": {
         "TEST_SSHD_USEDNS_NO": "True"
@@ -72,13 +74,13 @@
     {
       "name": "centos-8",
       "centoshtml": "https://cloud.centos.org/centos/8-stream/x86_64/images",
+      "container": "quay.io/centos/centos:stream8",
       "openstack_image": "CentOS-8-x86_64-GenericCloud-released-latest",
       "upload_results": true,
       "setup": [
         {
           "name": "Enable HA repos",
           "hosts": "all",
-          "become": true,
           "gather_facts": false,
           "tasks": [
             { "name": "Enable HA repos",
@@ -91,13 +93,13 @@
     {
       "name": "centos-9",
       "centoshtml": "https://cloud.centos.org/centos/9-stream/x86_64/images",
+      "container": "quay.io/centos/centos:stream9",
       "openstack_image": "CentOS-9-x86_64-GenericCloud-released-latest",
       "upload_results": true,
       "setup": [
         {
           "name": "Enable HA repos",
           "hosts": "all",
-          "become": true,
           "gather_facts": false,
           "tasks": [
             { "name": "Enable HA repos",

--- a/index.md
+++ b/index.md
@@ -75,6 +75,7 @@ If you would prefer to use a collection instead of individual roles, see
 
 ## Subsystems on the roadmap
 
+- [podman](https://github.com/linux-system-roles/podman)
 - AuditD
 - Red Hat Subscription Management
 - Kerberos authentication


### PR DESCRIPTION
- use centoshtml for c8s and c9s; add c9s
- add support for containers
- add podman to roadmap
- add email, irc, and github discussions links