### PR TITLE
Update documentation/howto/tag-and-release-role.md

### DIFF
--- a/contribute.md
+++ b/contribute.md
@@ -335,6 +335,11 @@ https://github.com/linux-system-roles/linux-system-roles.github.io/pulls - once
 your PR is merged, it may take a few minutes before it is published at
 https://linux-system-roles.github.io/blog/  NOTE: If you are viewing the above in plain text or github markdown render, replace the `lcub` template with `{` and the `rcub` template with `}`.
 
+## Update Changelogs, Tag, and Release a Role Repo
+
+Tagging and releasing a role repo is now automated by updating the CHANGELOG.md file.
+Please see {% link documentation/howto/tag-and-release-role.md %} for more details.
+
 ## How to reach us
 The mailing list for developers: systemroles@lists.fedorahosted.org
 

--- a/documentation/howto/tag-and-release-role.md
+++ b/documentation/howto/tag-and-release-role.md
@@ -1,15 +1,15 @@
 ---
 layout: page
-title: System Roles - How to Tag and Release a Role Repo
+title: System Roles - How to Update Changelogs, Tag, and Release a Role Repo
 ---
 We use [Semantic Versioning](https://semver.org) for release numbering.  We use
 the release number for the git tag and for the version number used when
 publishing to [Ansible Galaxy](https://galaxy.ansible.com)
 
-There are some helper scripts for tagging and publishing roles, and releasing a
-collection by converting the roles into a collection, checking, and publishing
-to Galaxy.  See
-[roles-tag-and-release.sh](https://github.com/linux-system-roles/auto-maintenance/#roles-tag-and-releasesh)
+There are some helper scripts for updating changelogs, tagging, and publishing roles,
+and releasing a collection by converting the roles into a collection, checking,
+and publishing to Galaxy.  See
+[role-make-version-changelog.sh](https://github.com/linux-system-roles/auto-maintenance#role-make-version-changelogsh)
 and
 [release_collection.py](https://github.com/linux-system-roles/auto-maintenance/#release_collectionpy)
 
@@ -31,35 +31,51 @@ This includes the git tag - the git tag should be **identical** to the version
 number - do not use git tags like `v1.1.0` or `1.1.0-rc` - it must be strictly
 `X.Y.Z`.
 
-## Create Git Tag and Release on Github
+## Update changelogs, Create Git Tag, and Release on Github
 
-Go to the page `https://github.com/linux-system-roles/$ROLENAME/releases/new`
-e.g. https://github.com/linux-system-roles/network/releases/new
+Script [role-make-version-changelog.sh](https://github.com/linux-system-roles/auto-maintenance#role-make-version-changelogsh) is used to create a new version,
+tag, and release for a role. It will guide you through the process.
+It will show you the changes in the role since the last tag, and ask you
+what will be the new semantic version to use for the tag. It will then put
+the changes in a file to use for the update to the CHANGELOG.md file for
+the new version, and put you in your editor to edit the file. If you are
+using this in conjunction with local-repo-dev-sync.sh, it will push the
+changes to your repo and create a pull request for CHANGELOG.md. Once the
+CHANGELOG.md PR is merged, there is github action automation to tag the
+repo with the version, create a github release, and import the new version
+into Ansible Galaxy.
 
-Fill in the version in `X.Y.Z` format - this will also create the git tag if you
-have not already done so.  Select the branch to tag (usually `main` or
-`master`).
+For an example of a good changelog and the corresponding release, see
+https://github.com/linux-system-roles/network/blob/main/CHANGELOG.md#1100---2022-11-01
+https://github.com/linux-system-roles/network/releases/tag/1.10.0
 
-Give the release a descriptive title, and provide release notes in the text
-field.
-
-For an example of a good release, see
-https://github.com/linux-system-roles/network/releases/tag/1.3.0
+The example network [1.10.0] shows all three sections have one or more items.
+If there are no items in a section, omit the section.
 
 ## Publish on Ansible Galaxy
+
+The github action automation should do everything for you - tag, github repo
+release, and publish to Galaxy.
+
+If for some reason you need to manually publish a role, you must first ensure
+the role is tagged and there is a github release.  Then, use
+```
+ansible-galaxy role import -vv --branch main linux-system-roles $ROLENAME
+```
+The Galaxy UI import method might also work.  If you want to use that method:
 
 Go to https://galaxy.ansible.com/my-content/namespaces
 
 Select your namespace e.g. `linux-system-roles`
 
-Find the repository you are interested in.  On the right hand side of the window
-will be a button called `Import`. Click this button to start importing.  Galaxy
-will import and create releases for each release under
-`https://github.com/linux-system-roles/$ROLENAME/releases`.  Once the import is
-complete, go to the role's page on Galaxy e.g.
-`https://galaxy.ansible.com/linux-system-roles/network`.  You should see your
-release version listed under `Versions`.  If you do not, check the import log
-for errors.
+Find the repository you are interested in. On the right hand side of the
+window will be a button called Import. Click this button to start importing.
+Galaxy will import and create releases for each release under
+`https://github.com/linux-system-roles/$ROLENAME/releases`.
+Once the import is complete, go to the role's page on Galaxy e.g.
+`https://galaxy.ansible.com/linux-system-roles/network`.
+You should see your release version listed under `Versions`. If you do not,
+check the import log for errors.
 
 ## Test role install
 


### PR DESCRIPTION
- Replace roles-tag-and-release.sh with role-make-version-changelog.sh
- Update "Create Git Tag and Release on Github" to explain merging the updated CHANGELOG.md file automatically tags and releases. Also, add the note to omit the entire section if the section has no items.