### PR TITLE
Remove Fedora 38 and 39, add 41 and 42, bump rawhide min_ansible_version to 2.16

### DIFF
--- a/download/linux-system-roles.json
+++ b/download/linux-system-roles.json
@@ -18,7 +18,7 @@
       "container": "registry.fedoraproject.org/fedora-toolbox:rawhide",
       "openstack_image": "Fedora-Cloud-Base-Rawhide",
       "upload_results": true,
-      "min_ansible_version": "2.9"
+      "min_ansible_version": "2.16"
     },
     {
       "name": "centos-6",

--- a/download/linux-system-roles.json
+++ b/download/linux-system-roles.json
@@ -1,21 +1,6 @@
 {
   "images": [
     {
-      "name": "fedora-38",
-      "compose": "https://kojipkgs.fedoraproject.org/compose/cloud/latest-Fedora-Cloud-38/compose/",
-      "container": "registry.fedoraproject.org/fedora-toolbox:38",
-      "openstack_image": "Fedora-Cloud-Base-38",
-      "min_ansible_version": "2.9"
-    },
-    {
-      "name": "fedora-39",
-      "compose": "https://kojipkgs.fedoraproject.org/compose/cloud/latest-Fedora-Cloud-39/compose/",
-      "container": "registry.fedoraproject.org/fedora-toolbox:39",
-      "openstack_image": "Fedora-Cloud-Base-39",
-      "upload_results": true,
-      "min_ansible_version": "2.9"
-    },
-    {
       "name": "fedora-40",
       "variant": "Generic",
       "subvariant": "Cloud_Base",

--- a/download/linux-system-roles.json
+++ b/download/linux-system-roles.json
@@ -11,6 +11,26 @@
       "min_ansible_version": "2.9"
     },
     {
+      "name": "fedora-41",
+      "variant": "Generic",
+      "subvariant": "Cloud_Base",
+      "compose": "https://kojipkgs.fedoraproject.org/compose/41/latest-Fedora-41/compose/",
+      "container": "registry.fedoraproject.org/fedora-toolbox:41",
+      "openstack_image": "Fedora-Cloud-Base-41",
+      "upload_results": true,
+      "min_ansible_version": "2.16"
+    },
+    {
+      "name": "fedora-42",
+      "variant": "Generic",
+      "subvariant": "Cloud_Base",
+      "compose": "https://kojipkgs.fedoraproject.org/compose/42/latest-Fedora-42/compose/",
+      "container": "registry.fedoraproject.org/fedora-toolbox:42",
+      "openstack_image": "Fedora-Cloud-Base-42",
+      "upload_results": true,
+      "min_ansible_version": "2.16"
+    },
+    {
       "name": "fedora-rawhide",
       "variant": "Generic",
       "subvariant": "Cloud_Base",


### PR DESCRIPTION
Tested with
```
ln -sfn ~/upstream/lsr/linux-system-roles.github.io/download/linux-system-roles.json ~/.config/linux-system-roles.json
```

and in a [sudo role checkout](https://github.com/linux-system-roles/sudo):
```
tox -e qemu-ansible-core-2.16 -- --image-name fedora-41 tests/tests_default.yml
tox -e qemu-ansible-core-2.16 -- --image-name fedora-42 tests/tests_default.yml
```