### PR TITLE
Add CentOS 10 cloud image download URL

### DIFF
--- a/download/linux-system-roles.json
+++ b/download/linux-system-roles.json
@@ -134,6 +134,7 @@
     },
     {
       "name": "centos-10",
+      "source": "https://cloud.centos.org/centos/10-stream/x86_64/images/CentOS-Stream-GenericCloud-10-latest.x86_64.qcow2",
       "compose": "https://composes.stream.centos.org/stream-10/production/latest-CentOS-Stream/compose/",
       "variant": "BaseOS",
       "subvariant": "generic",


### PR DESCRIPTION
Tested with 

    tox -e qemu-ansible-core-2.16 -- --image-name centos-10 tests/tests_default.yml tests/tests_multiple_sudoers.yml

in the sudo role. It [currently fails](https://github.com/martinpitt/lsr-sudo/actions/runs/14213995302/job/39826400483) because it cannot download the image. See https://github.com/linux-system-roles/sudo/pull/46