### PR TITLE
Add CentOS 9/10 bootc container

### DIFF
--- a/download/linux-system-roles.json
+++ b/download/linux-system-roles.json
@@ -133,6 +133,12 @@
       ]
     },
     {
+      "name": "centos-9-bootc",
+      "container": "quay.io/centos-bootc/centos-bootc:stream9",
+      "upload_results": true,
+      "setup": []
+    },
+    {
       "name": "centos-10",
       "source": "https://cloud.centos.org/centos/10-stream/x86_64/images/CentOS-Stream-GenericCloud-10-latest.x86_64.qcow2",
       "compose": "https://composes.stream.centos.org/stream-10/production/latest-CentOS-Stream/compose/",
@@ -167,6 +173,12 @@
           ]
         }
       ]
+    },
+    {
+      "name": "centos-10-bootc",
+      "container": "quay.io/centos-bootc/centos-bootc:stream10",
+      "upload_results": true,
+      "setup": []
     }
   ]
 }


### PR DESCRIPTION
There are no cloud/qcow2 images (by design), so we always have to start from a locally built container and build a QEMU image out of that.

---

This of course needs some corresponding logic in tox-lsr and the workflows. I put it all together in my fork, you can [see a successful run here](https://github.com/martinpitt/lsr-sudo/actions/runs/14615961638/job/41004496814). I'll experiment with this stuff a bit still and spoonfeed it as PRs. But I think this part is stable now, and also quite obvious.